### PR TITLE
Expose CrontabFields on CrontabSchedule

### DIFF
--- a/NCrontab.Tests/NCrontab.Tests.csproj
+++ b/NCrontab.Tests/NCrontab.Tests.csproj
@@ -38,8 +38,8 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.5.0\lib\net35\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -57,10 +57,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Properties\" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/NCrontab.Tests/packages.config
+++ b/NCrontab.Tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net35" />
+  <package id="NUnit" version="3.5.0" targetFramework="net35" />
 </packages>

--- a/NCrontab/CrontabSchedule.cs
+++ b/NCrontab/CrontabSchedule.cs
@@ -37,14 +37,14 @@ namespace NCrontab
 
     public sealed partial class CrontabSchedule
     {
-        readonly CrontabField _seconds;
-        readonly CrontabField _minutes;
-        readonly CrontabField _hours;
-        readonly CrontabField _days;
-        readonly CrontabField _months;
-        readonly CrontabField _daysOfWeek;
+        public readonly CrontabField Seconds;
+        public readonly CrontabField Minutes;
+        public readonly CrontabField Hours;
+        public readonly CrontabField Days;
+        public readonly CrontabField Months;
+        public readonly CrontabField DaysOfWeek;
 
-        static readonly CrontabField SecondZero = CrontabField.Seconds("0");
+        private static readonly CrontabField SecondZero = CrontabField.Seconds("0");
 
         // ReSharper disable once PartialTypeWithSinglePart
 
@@ -152,12 +152,12 @@ namespace NCrontab
             Debug.Assert(months != null);
             Debug.Assert(daysOfWeek != null);
 
-            _seconds = seconds;
-            _minutes = minutes;
-            _hours = hours;
-            _days = days;
-            _months = months;
-            _daysOfWeek = daysOfWeek;
+            Seconds = seconds;
+            Minutes = minutes;
+            Hours = hours;
+            Days = days;
+            Months = months;
+            DaysOfWeek = daysOfWeek;
         }
 
         /// <summary>
@@ -235,7 +235,7 @@ namespace NCrontab
             // Second
             //
 
-            var seconds = _seconds ?? SecondZero;
+            var seconds = Seconds ?? SecondZero;
             second = seconds.Next(second);
 
             if (second == nil)
@@ -248,11 +248,11 @@ namespace NCrontab
             // Minute
             //
 
-            minute = _minutes.Next(minute);
+            minute = Minutes.Next(minute);
 
             if (minute == nil)
             {
-                minute = _minutes.GetFirst();
+                minute = Minutes.GetFirst();
                 hour++;
             }
 
@@ -260,63 +260,63 @@ namespace NCrontab
             // Hour
             //
 
-            hour = _hours.Next(hour);
+            hour = Hours.Next(hour);
 
             if (hour == nil)
             {
-                minute = _minutes.GetFirst();
-                hour = _hours.GetFirst();
+                minute = Minutes.GetFirst();
+                hour = Hours.GetFirst();
                 day++;
             }
             else if (hour > baseHour)
             {
-                minute = _minutes.GetFirst();
+                minute = Minutes.GetFirst();
             }
 
             //
             // Day
             //
 
-            day = _days.Next(day);
+            day = Days.Next(day);
 
             RetryDayMonth:
 
             if (day == nil)
             {
                 second = seconds.GetFirst();
-                minute = _minutes.GetFirst();
-                hour = _hours.GetFirst();
-                day = _days.GetFirst();
+                minute = Minutes.GetFirst();
+                hour = Hours.GetFirst();
+                day = Days.GetFirst();
                 month++;
             }
             else if (day > baseDay)
             {
                 second = seconds.GetFirst();
-                minute = _minutes.GetFirst();
-                hour = _hours.GetFirst();
+                minute = Minutes.GetFirst();
+                hour = Hours.GetFirst();
             }
 
             //
             // Month
             //
 
-            month = _months.Next(month);
+            month = Months.Next(month);
 
             if (month == nil)
             {
                 second = seconds.GetFirst();
-                minute = _minutes.GetFirst();
-                hour = _hours.GetFirst();
-                day = _days.GetFirst();
-                month = _months.GetFirst();
+                minute = Minutes.GetFirst();
+                hour = Hours.GetFirst();
+                day = Days.GetFirst();
+                month = Months.GetFirst();
                 year++;
             }
             else if (month > baseMonth)
             {
                 second = seconds.GetFirst();
-                minute = _minutes.GetFirst();
-                hour = _hours.GetFirst();
-                day = _days.GetFirst();
+                minute = Minutes.GetFirst();
+                hour = Hours.GetFirst();
+                day = Days.GetFirst();
             }
 
             //
@@ -356,7 +356,7 @@ namespace NCrontab
             // Day of week
             //
 
-            if (_daysOfWeek.Contains((int) nextTime.DayOfWeek))
+            if (DaysOfWeek.Contains((int) nextTime.DayOfWeek))
                 return nextTime;
 
             return GetNextOccurrence(new DateTime(year, month, day, 23, 59, 59, 0, baseTime.Kind), endTime);
@@ -371,16 +371,16 @@ namespace NCrontab
         {
             var writer = new StringWriter(CultureInfo.InvariantCulture);
 
-            if (_seconds != null)
+            if (Seconds != null)
             {
-                _seconds.Format(writer, true);
+                Seconds.Format(writer, true);
                 writer.Write(' ');
             }
-            _minutes.Format(writer, true); writer.Write(' ');
-            _hours.Format(writer, true); writer.Write(' ');
-            _days.Format(writer, true); writer.Write(' ');
-            _months.Format(writer, true); writer.Write(' ');
-            _daysOfWeek.Format(writer, true);
+            Minutes.Format(writer, true); writer.Write(' ');
+            Hours.Format(writer, true); writer.Write(' ');
+            Days.Format(writer, true); writer.Write(' ');
+            Months.Format(writer, true); writer.Write(' ');
+            DaysOfWeek.Format(writer, true);
 
             return writer.ToString();
         }


### PR DESCRIPTION
One portion of an application I'm writing needs to inspect the CrontabField values on the CrontabSchedule, but they're currently private, so I made them public (didn't see much harm in exposing them). I also noticed NUnit was out of date, so I updated it to the latest version while I was at it.