### PR TITLE
Document six-part expressions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ NCrontab is a library written in C# targeting [.NET Standard Library][netstd]
 This library does not provide any scheduler or is not a scheduling facility like
 cron from Unix platforms. What it provides is parsing, formatting and an algorithm
 to produce occurrences of time based on a give schedule expressed in the crontab
-format:
+or six-part expression format:
 
+    Crontab expression format:
     * * * * *
     - - - - -
     | | | | |
@@ -23,6 +24,17 @@ format:
     | | +--------- day of month (1 - 31)
     | +----------- hour (0 - 23)
     +------------- min (0 - 59)
+
+    Six-part expression format:
+    * * * * * *
+    - - - - - -
+    | | | | | |
+    | | | | | +--- day of week (0 - 6) (Sunday=0)
+    | | | | +----- month (1 - 12)
+    | | | +------- day of month (1 - 31)
+    | | +--------- hour (0 - 23)
+    | +----------- min (0 - 59)
+    +------------- sec (0 - 59)
 
 Star (`*`) in the value field above means all legal values as in parentheses for
 that column. The value column can have a `*` or a list of elements separated by

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ NCrontab is a library written in C# targeting [.NET Standard Library][netstd]
 This library does not provide any scheduler or is not a scheduling facility like
 cron from Unix platforms. What it provides is parsing, formatting and an algorithm
 to produce occurrences of time based on a give schedule expressed in the crontab
-or six-part expression format:
+format:
 
-    Crontab expression format:
     * * * * *
     - - - - -
     | | | | |
@@ -25,7 +24,8 @@ or six-part expression format:
     | +----------- hour (0 - 23)
     +------------- min (0 - 59)
 
-    Six-part expression format:
+or a six-part format that allows for seconds:
+
     * * * * * *
     - - - - - -
     | | | | | |


### PR DESCRIPTION
CrontabSchedule supports crontab and six-part expressions. Make this more discoverable, esp. since Azure WebJobs use the six-part format: https://github.com/Azure/azure-webjobs-sdk-script/issues/482