### PR TITLE
Remove test project properties predicated on "netcoreapp1.0"

### DIFF
--- a/NCrontab.Tests/NCrontab.Tests.csproj
+++ b/NCrontab.Tests/NCrontab.Tests.csproj
@@ -4,8 +4,6 @@
     <TargetFrameworks>netcoreapp3.1;net451</TargetFrameworks>
     <DebugType>portable</DebugType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR removes test project properties predicated on `netcoreapp1.0`, which is not a target (anymore).