### PR TITLE
Remove redundant initialization of field bitmap

### DIFF
--- a/NCrontab/CrontabField.cs
+++ b/NCrontab/CrontabField.cs
@@ -107,8 +107,6 @@ namespace NCrontab
 
             _impl = impl;
             _bits = new BitArray(impl.ValueCount);
-
-            _bits.SetAll(false);
             _minValueSet = int.MaxValue;
             _maxValueSet = -1;
         }


### PR DESCRIPTION
Resetting the bitmap to zeros is redundant with `BitArray` construction/initialization. This PR removes the redundancy.