### PR TITLE
Remove CI patch for "dotnet-install.sh" bug

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,10 +23,7 @@ install:
   - ps: if ($isWindows) { ./dotnet-install.ps1 -JsonFile global.json }
   - sh: curl -OsSL https://dot.net/v1/dotnet-install.sh
   - sh: chmod +x dotnet-install.sh
-  # https://github.com/dotnet/install-scripts/issues/71
-# - sh: ./dotnet-install.sh --jsonfile global.json
-  - sh: sudo apt install -y jq
-  - sh: ./dotnet-install.sh --version $(jq -r .sdk.version global.json)
+  - sh: ./dotnet-install.sh --jsonfile global.json
   - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info


### PR DESCRIPTION
This PR removes the CI patch for `global.json` parsing bug in `dotnet-install.sh` (see dotnet/install-scripts#7), which [seems to be fixed and published now](https://github.com/dotnet/install-scripts/issues/7#issuecomment-724680762).