### PR TITLE
Change option IncludeSeconds to RequireSeconds

### DIFF
--- a/NCrontab/PublicAPI/net35/PublicAPI.Shipped.txt
+++ b/NCrontab/PublicAPI/net35/PublicAPI.Shipped.txt
@@ -23,8 +23,8 @@ NCrontab.CrontabSchedule.GetNextOccurrence(System.DateTime baseTime) -> System.D
 NCrontab.CrontabSchedule.GetNextOccurrence(System.DateTime baseTime, System.DateTime endTime) -> System.DateTime
 NCrontab.CrontabSchedule.GetNextOccurrences(System.DateTime baseTime, System.DateTime endTime) -> System.Collections.Generic.IEnumerable<System.DateTime>!
 NCrontab.CrontabSchedule.ParseOptions
-NCrontab.CrontabSchedule.ParseOptions.IncludingSeconds.get -> bool
-NCrontab.CrontabSchedule.ParseOptions.IncludingSeconds.set -> void
+NCrontab.CrontabSchedule.ParseOptions.RequireSeconds.get -> bool
+NCrontab.CrontabSchedule.ParseOptions.RequireSeconds.set -> void
 NCrontab.CrontabSchedule.ParseOptions.ParseOptions() -> void
 NCrontab.ExceptionProvider
 NCrontab.ICrontabField

--- a/NCrontab/PublicAPI/netstandard1.0/PublicAPI.Shipped.txt
+++ b/NCrontab/PublicAPI/netstandard1.0/PublicAPI.Shipped.txt
@@ -22,8 +22,8 @@ NCrontab.CrontabSchedule.GetNextOccurrence(System.DateTime baseTime) -> System.D
 NCrontab.CrontabSchedule.GetNextOccurrence(System.DateTime baseTime, System.DateTime endTime) -> System.DateTime
 NCrontab.CrontabSchedule.GetNextOccurrences(System.DateTime baseTime, System.DateTime endTime) -> System.Collections.Generic.IEnumerable<System.DateTime>!
 NCrontab.CrontabSchedule.ParseOptions
-NCrontab.CrontabSchedule.ParseOptions.IncludingSeconds.get -> bool
-NCrontab.CrontabSchedule.ParseOptions.IncludingSeconds.set -> void
+NCrontab.CrontabSchedule.ParseOptions.RequireSeconds.get -> bool
+NCrontab.CrontabSchedule.ParseOptions.RequireSeconds.set -> void
 NCrontab.CrontabSchedule.ParseOptions.ParseOptions() -> void
 NCrontab.ExceptionProvider
 NCrontab.ICrontabField

--- a/NCrontab/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/NCrontab/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -22,8 +22,8 @@ NCrontab.CrontabSchedule.GetNextOccurrence(System.DateTime baseTime) -> System.D
 NCrontab.CrontabSchedule.GetNextOccurrence(System.DateTime baseTime, System.DateTime endTime) -> System.DateTime
 NCrontab.CrontabSchedule.GetNextOccurrences(System.DateTime baseTime, System.DateTime endTime) -> System.Collections.Generic.IEnumerable<System.DateTime>!
 NCrontab.CrontabSchedule.ParseOptions
-NCrontab.CrontabSchedule.ParseOptions.IncludingSeconds.get -> bool
-NCrontab.CrontabSchedule.ParseOptions.IncludingSeconds.set -> void
+NCrontab.CrontabSchedule.ParseOptions.RequireSeconds.get -> bool
+NCrontab.CrontabSchedule.ParseOptions.RequireSeconds.set -> void
 NCrontab.CrontabSchedule.ParseOptions.ParseOptions() -> void
 NCrontab.ExceptionProvider
 NCrontab.ICrontabField

--- a/NCrontabConsole/Program.cs
+++ b/NCrontabConsole/Program.cs
@@ -46,13 +46,12 @@ try
     expression = expression.Trim();
     var options = new CrontabSchedule.ParseOptions
     {
-        IncludingSeconds = expression.Split(' ').Length > 5,
+        RequireSeconds = expression.Split(' ').Length > 5,
     };
 
     var start = ParseDateArgument(startTimeString, "start");
     var end = ParseDateArgument(endTimeString, "end");
-    format = format ?? (options.IncludingSeconds ? "ddd, dd MMM yyyy HH:mm:ss"
-                                                 : "ddd, dd MMM yyyy HH:mm");
+    format ??= options.RequireSeconds ? "ddd, dd MMM yyyy HH:mm:ss" : "ddd, dd MMM yyyy HH:mm";
 
     var schedule = CrontabSchedule.Parse(expression, options);
 

--- a/NCrontabViewer/MainForm.cs
+++ b/NCrontabViewer/MainForm.cs
@@ -84,7 +84,7 @@ namespace NCrontabViewer
                         return;
 
                     _isSixPart = expression.Split(Separators, StringSplitOptions.RemoveEmptyEntries).Length == 6;
-                    _crontab = CrontabSchedule.Parse(expression, new CrontabSchedule.ParseOptions { IncludingSeconds = _isSixPart });
+                    _crontab = CrontabSchedule.Parse(expression, new CrontabSchedule.ParseOptions { RequireSeconds = _isSixPart });
 
                     _totalOccurrenceCount = 0;
 


### PR DESCRIPTION
Hiya. Feel free to ignore this PR if it's not what you had in mind.

For my uses, having to specify via an options file whether I want to include seconds in the cron expression or not is a little tedious, and you already have nearly all the infrastructure in place to handle either 5 or 6 tokens automatically. So this is me giving it that one final push. Now whenever `RequireSeconds` is set true, the parser will throw only if Seconds are missing. Otherwise, if it's false, it'll accept 5 or 6 tokens without issue.

Sorry for all the renaming. The meat-and-potatoes of this change is a new test method, `CrontabScheduleTests.CanParseEitherFormatWhenSecondsAreNotRequired`, and the slightly modified implementation of `CrontabSchedule.TryParse<T>`.

Let me know what you think and if you'd like me to make any changes. Thanks for making this! Very useful :)