### PR TITLE
Update to .NET SDK 7.0

### DIFF
--- a/NCrontab.Tests/NCrontab.Tests.csproj
+++ b/NCrontab.Tests/NCrontab.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5;netcoreapp3.1;net451</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net451</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/NCrontabConsole/NCrontabConsole.csproj
+++ b/NCrontabConsole/NCrontabConsole.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/NCrontabViewer/NCrontabViewer.csproj
+++ b/NCrontabViewer/NCrontabViewer.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '{build}'
 image:
-  - Visual Studio 2019
+  - Visual Studio 2022
   - Ubuntu
 branches:
   only:
@@ -21,10 +21,11 @@ environment:
 install:
   - cmd: curl -OsSL https://dot.net/v1/dotnet-install.ps1
   - ps: if ($isWindows) { ./dotnet-install.ps1 -JsonFile global.json }
+  - ps: if ($isWindows) { ./dotnet-install.ps1 -Runtime dotnet -Version 6.0.16 }
   - sh: curl -OsSL https://dot.net/v1/dotnet-install.sh
   - sh: chmod +x dotnet-install.sh
-  - sh: ./dotnet-install.sh --runtime dotnet --version 3.1.10
   - sh: ./dotnet-install.sh --jsonfile global.json
+  - sh: ./dotnet-install.sh --runtime dotnet --version 6.0.16
   - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info
@@ -39,7 +40,7 @@ for:
 -
   matrix:
     only:
-      - image: Visual Studio 2019
+      - image: Visual Studio 2022
   artifacts:
   - path: dist\*.nupkg
   deploy:

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ for p in NCrontabConsole NCrontab.Tests; do {
 }
 done
 for c in Debug Release; do {
-    dotnet build --no-restore -c $c -f net5 NCrontabConsole
+    dotnet build --no-restore -c $c NCrontabConsole
     for f in net7.0 net6.0; do {
         dotnet build --no-restore -c $c -f $f NCrontab.Tests
     }

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ for p in NCrontabConsole NCrontab.Tests; do {
 done
 for c in Debug Release; do {
     dotnet build --no-restore -c $c -f net5 NCrontabConsole
-    for f in net5 netcoreapp3.1; do {
+    for f in net7.0 net6.0; do {
         dotnet build --no-restore -c $c -f $f NCrontab.Tests
     }
     done

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100"
+    "version": "7.0.200",
+    "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.200",
+    "version": "7.0.302",
     "rollForward": "latestFeature"
   }
 }

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 set -e
 cd "$(dirname "$0")"
 ./build.sh
-for f in net5 netcoreapp3.1; do {
+for f in net7.0 net6.0; do {
     dotnet test --no-build NCrontab.Tests -c Debug -f $f \
         -p:CollectCoverage=true \
         -p:CoverletOutputFormat=opencover \


### PR DESCRIPTION
This PR updates the solution to use .NET SDK 7.0. It replaces the [.NET 5 target, which reached end-of-life](https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-and-net-core) with .NET 6 (LTS).