### PR TITLE
Replace deprecated package with .NET Framework 3.5 reference assemblies

### DIFF
--- a/NCrontab.Signed/NCrontab.Signed.csproj
+++ b/NCrontab.Signed/NCrontab.Signed.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <PackageReference Include="JetBrains.NETFramework.ReferenceAssemblies.net35" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net35" Version="1.0.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' ">

--- a/NCrontab/NCrontab.csproj
+++ b/NCrontab/NCrontab.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <PackageReference Include="JetBrains.NETFramework.ReferenceAssemblies.net35" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net35" Version="1.0.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' ">


### PR DESCRIPTION
This PR replaces deprecated package [JetBrains.NETFramework.ReferenceAssemblies.net35](https://www.nuget.org/packages/JetBrains.NETFramework.ReferenceAssemblies.net35/) with [Microsoft.NETFramework.ReferenceAssemblies.net35](https://www.nuget.org/packages/Microsoft.NETFramework.ReferenceAssemblies.net35/), per the suggested alternative for the former.