### PR TITLE
Add test coverage collection & reporting

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.1.22",
+      "commands": [
+        "reportgenerator"
+      ]
+    }
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ indent_size = 2
 [*.{sln}]
 indent_style = tab
 
-[*.{json,yml}]
+[*.{json,yml,xml,runsettings}]
 indent_size = 2
 
 [*.{cs,tt}]

--- a/.gitignore
+++ b/.gitignore
@@ -370,3 +370,4 @@ __pycache__/
 
 temp/
 tmp/
+etc/coverage/

--- a/NCrontab.Tests/.runsettings
+++ b/NCrontab.Tests/.runsettings
@@ -1,0 +1,7 @@
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage" />
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/NCrontab.Tests/NCrontab.Tests.csproj
+++ b/NCrontab.Tests/NCrontab.Tests.csproj
@@ -10,6 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,10 @@ build_script:
     $id = ([datetimeoffset]$env:APPVEYOR_REPO_COMMIT_TIMESTAMP).ToUniversalTime().ToString('yyyyMMdd''t''HHmm')
     if ($isWindows) { .\pack.cmd ci-$id }
 test_script:
-- cmd: test.cmd
+- cmd: |
+    call test.cmd
+    curl -OsSL https://uploader.codecov.io/latest/windows/codecov.exe
+    codecov
 - sh: ./test.sh
 for:
 -
@@ -44,6 +47,7 @@ for:
       - image: Visual Studio 2022
   artifacts:
   - path: dist\*.nupkg
+  - path: etc\coverage
   deploy:
   - provider: NuGet
     server: https://www.myget.org/F/raboof/api/v2/package

--- a/test.cmd
+++ b/test.cmd
@@ -1,17 +1,13 @@
 @echo off
 pushd "%~dp0"
-call :main %*
-popd
-goto :EOF
-
-:main
-    call build ^
- && call :test Debug -p:CollectCoverage=true ^
-                     -p:CoverletOutputFormat=opencover ^
-                     -p:Exclude=[NUnit*]* ^
- && call :test Release
-goto :EOF
+dotnet tool restore ^
+ && call build ^
+ && call :test Debug ^
+ && call :test Release ^
+ && dotnet reportgenerator -reports:NCrontab.Tests\TestResults\*\coverage.cobertura.xml -targetdir:etc\coverage -reporttypes:TextSummary;Html ^
+ && type etc\coverage\Summary.txt
+popd && exit /b %ERRORLEVEL%
 
 :test
-dotnet test --no-build -c %1 NCrontab.Tests
+dotnet test --no-build -s NCrontab.Tests\.runsettings -c %*
 goto :EOF

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@ for f in net7.0 net6.0; do
             -s NCrontab.Tests/.runsettings
     done
 done
-dotnet reportgenerator "-reports:NCrontab.Tests/TestResults/*/coverage.cobertura.xml" \
+dotnet reportgenerator '-reports:NCrontab.Tests/TestResults/*/coverage.cobertura.xml' \
     -targetdir:etc/coverage \
-    -reporttypes:TextSummary;Html
+    '-reporttypes:TextSummary;Html'
 cat etc/coverage/Summary.txt

--- a/test.sh
+++ b/test.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 set -e
 cd "$(dirname "$0")"
+dotnet tool restore
 ./build.sh
-for f in net7.0 net6.0; do {
-    dotnet test --no-build NCrontab.Tests -c Debug -f $f \
-        -p:CollectCoverage=true \
-        -p:CoverletOutputFormat=opencover \
-        -p:Exclude=[NUnit*]*
-    dotnet test --no-build NCrontab.Tests -c Release -f $f
-}
+for f in net7.0 net6.0; do
+    for c in Debug Release; do
+        dotnet test --no-build -c $c -f $f \
+            -s NCrontab.Tests/.runsettings
+    done
 done
+dotnet reportgenerator "-reports:NCrontab.Tests/TestResults/*/coverage.cobertura.xml" \
+    -targetdir:etc/coverage \
+    -reporttypes:TextSummary;Html
+cat etc/coverage/Summary.txt


### PR DESCRIPTION
This PR adds test coverage collection & reporting during a CI build as well as locally runnable test scripts (`test.cmd`/`test.sh`). When the test script finishes running, a summary as follows is printed:

    Summary
      Generated on: 13/06/2023 - 18:18:42
      Coverage date: 13/06/2023 - 18:03:24 - 13/06/2023 - 18:18:41
      Parser: MultiReport (12x Cobertura)
      Assemblies: 1
      Classes: 5
      Files: 5
      Line coverage: 88.3%
      Covered lines: 380
      Uncovered lines: 50
      Coverable lines: 430
      Total lines: 1039
      Branch coverage: 79.7% (169 of 212)
      Covered branches: 169
      Total branches: 212
      Method coverage: 79.7% (55 of 69)
      Covered methods: 55
      Total methods: 69

    NCrontab                          88.3%
      NCrontab.CrontabException       66.6%
      NCrontab.CrontabField           69.7%
      NCrontab.CrontabFieldImpl       89.7%
      NCrontab.CrontabSchedule        99.4%
      NCrontab.StringSeparatorStock  100.0%

The script generates detailed HTML report of the the code coverage into `etc/coverage` and the CI build publishes it as a downloadable artifact. Another online browsable report should also be available on [Codecov](https://about.codecov.io/).
