### PR TITLE
add ParseOptions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ commas. An element is either a number in the ranges shown above or two numbers i
 the range separated by a hyphen (meaning an inclusive range). For more, see
 [CrontabExpression].
 
-The default `Parse` format is five-part cron format.  In order to use six-part format that includes seconds pass a `ParseOptions` to `Parse` with `IncludingSeconds=true`. For example,
+The default `Parse` format is five-part cron format.  In order to use six-part
+format that includes seconds pass a `ParseOptions` to `Parse` with
+`IncludingSeconds=true`. For example,
 
 ```csharp
 var s = CrontabSchedule.Parse(

--- a/README.md
+++ b/README.md
@@ -48,12 +48,11 @@ format. In order to use the six-part format that includes seconds, pass a
 `true`. For example:
 
 ```csharp
-var s = CrontabSchedule.Parse(
-    "0,30 * * * * *",
-    new CrontabSchedule.ParseOptions
-    {
-        IncludingSeconds = true
-    });
+var s = CrontabSchedule.Parse("0,30 * * * * *",
+                              new CrontabSchedule.ParseOptions
+                              {
+                                  IncludingSeconds = true
+                              });
 ```
 
 Below is an example in [IronPython][ipy] of how to use `CrontabSchedule` class

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ the range separated by a hyphen (meaning an inclusive range). For more, see
 
 The default format parsed by `CrontabSchedule.Parse` is the five-part cron
 format. In order to use the six-part format that includes seconds, pass a
-`ParseOptions` to `Parse` with `IncludingSeconds` set to `true`. For example:
+`CrontabSchedule.ParseOptions` to `Parse` with `IncludingSeconds` set to
+`true`. For example:
 
 ```csharp
 var s = CrontabSchedule.Parse(

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ commas. An element is either a number in the ranges shown above or two numbers i
 the range separated by a hyphen (meaning an inclusive range). For more, see
 [CrontabExpression].
 
-The default `Parse` format is five-part cron format.  In order to use six-part
-format that includes seconds pass a `ParseOptions` to `Parse` with
-`IncludingSeconds=true`. For example,
+The default `CrontabSchedule.Parse` format is five-part cron format.  In order
+to use six-part format that includes seconds pass a `ParseOptions` to `Parse`
+with `IncludingSeconds=true`. For example,
 
 ```csharp
 var s = CrontabSchedule.Parse(

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ commas. An element is either a number in the ranges shown above or two numbers i
 the range separated by a hyphen (meaning an inclusive range). For more, see
 [CrontabExpression].
 
+The default `Parse` format is five-part cron format.  In order to use six-part format that includes seconds pass a `ParseOptions` to `Parse` with `IncludingSeconds=true`. For example,
+
+```csharp
+var s = CrontabSchedule.Parse(
+    "0,30 * * * * *",
+    new CrontabSchedule.ParseOptions
+    {
+        IncludingSeconds = true
+    });
+```
+
 Below is an example in [IronPython][ipy] of how to use `CrontabSchedule` class
 from NCrontab to generate occurrences of the schedule `0 12 * */2 Mon`
 (meaning, *12:00 PM on Monday of every other month, starting with January*)

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ commas. An element is either a number in the ranges shown above or two numbers i
 the range separated by a hyphen (meaning an inclusive range). For more, see
 [CrontabExpression].
 
-The default `CrontabSchedule.Parse` format is five-part cron format.  In order
-to use six-part format that includes seconds pass a `ParseOptions` to `Parse`
-with `IncludingSeconds=true`. For example,
+The default format parsed by `CrontabSchedule.Parse` is the five-part cron
+format. In order to use the six-part format that includes seconds, pass a
+`ParseOptions` to `Parse` with `IncludingSeconds` set to `true`. For example:
 
 ```csharp
 var s = CrontabSchedule.Parse(


### PR DESCRIPTION
Add a brief explanation for using six-part format to the README.