### PR TITLE
Update to use .NET SDK 8 with latest dependencies

### DIFF
--- a/NCrontab.Signed/NCrontab.Signed.csproj
+++ b/NCrontab.Signed/NCrontab.Signed.csproj
@@ -50,11 +50,11 @@
     <PackageReference Include="System.Globalization" Version="4.3.0" />
     <PackageReference Include="System.IO" Version="4.3.0" />
     <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.4" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/NCrontab.Tests/NCrontab.Tests.csproj
+++ b/NCrontab.Tests/NCrontab.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net451</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net451</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -10,13 +10,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/NCrontab/NCrontab.csproj
+++ b/NCrontab/NCrontab.csproj
@@ -45,15 +45,15 @@
     <PackageReference Include="System.Globalization" Version="4.3.0" />
     <PackageReference Include="System.IO" Version="4.3.0" />
     <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.4" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NCrontabConsole/NCrontabConsole.csproj
+++ b/NCrontabConsole/NCrontabConsole.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/NCrontabViewer/NCrontabViewer.csproj
+++ b/NCrontabViewer/NCrontabViewer.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ for p in NCrontabConsole NCrontab.Tests; do {
 done
 for c in Debug Release; do {
     dotnet build --no-restore -c $c NCrontabConsole
-    for f in net7.0 net6.0; do {
+    for f in net8.0 net6.0; do {
         dotnet build --no-restore -c $c -f $f NCrontab.Tests
     }
     done

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.302",
+    "version": "8.0.300",
     "rollForward": "latestFeature"
   }
 }

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@ set -e
 cd "$(dirname "$0")"
 dotnet tool restore
 ./build.sh
-for f in net7.0 net6.0; do
+for f in net8.0 net6.0; do
     for c in Debug Release; do
         dotnet test --no-build -c $c -f $f \
             -s NCrontab.Tests/.runsettings


### PR DESCRIPTION
This PR updates the solution to use .NET SDK 8 with latest versions of all dependencies. NUnit, however, remains at latest 3.x due to some [breaking changes](https://docs.nunit.org/articles/nunit/release-notes/breaking-changes.html#nunit-40) (like supporting only .NET Framework 4.6.2+).